### PR TITLE
Use reported frame count to ignore cap.read failures

### DIFF
--- a/dcc.py
+++ b/dcc.py
@@ -1,4 +1,3 @@
-from faulthandler import disable
 import PySimpleGUI as sg
 import os
 from correct import correct_image, analyze_video, process_video


### PR DESCRIPTION
In a few videos `cap.read` returns false before we reach end of video.
This contradicts what's stated in https://docs.opencv.org/4.x/dd/d43/tutorial_py_video_display.html

We now use `cv2.CAP_PROP_FRAME_COUNT` to check if we have indeed read all frames.